### PR TITLE
Changes for Firefox 55, gecko 0.18 and selenium 3.5.0

### DIFF
--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -8,10 +8,12 @@ from selenium.webdriver.common.keys import Keys
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):
-        sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
-                                                    'openquakeplatform',
-                                                    'test/shapefile',
-                                                    'exampleshape.zip')
+        # sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
+        #                                            'openquakeplatform',
+        #                                            'test/shapefile',
+        #                                            'exampleshape.zip')
+        sph = "~/oq-platform2/openquakeplatform/test/shapefile/exampleshape.zip"
+
         pla.get('')
 
         # layers in homepage

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -20,7 +20,7 @@ class ShapeTest(unittest.TestCase):
             100, 1)
         linklayer.click()
 
-        pla.wait_new_page(linklayer, '/layers', timeout=10)
+        pla.wait_new_page(linklayer, '/layers/?limit=100&offset=0', timeout=10)
 
         # upload layers
         uploadlayer = pla.xpath_finduniq(

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -6,7 +6,7 @@ from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
-@unittest.skip("temporarily disabled")
+# @unittest.skip("temporarily disabled")
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):
@@ -42,7 +42,7 @@ class ShapeTest(unittest.TestCase):
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",
              100, 1)
-        chooselayer.send_keys(sph)
+        chooselayer.upload.send_keys(sph)
 
         # confirm upload layers
         confuplayer = pla.xpath_finduniq(

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -6,7 +6,7 @@ from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
-# @unittest.skip("temporarily disabled")
+@unittest.skip("temporarily disabled")
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -6,6 +6,7 @@ from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
+@unittest.skip("temporarily disabled")
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -34,12 +34,14 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
-        import pdb ; pdb.set_trace()
+        # import pdb ; pdb.set_trace()
+
+        browser = webdriver.Firefox()
 
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",
              100, 1)
-        chooselayer.send_keys(sph)
+        chooselayer.send_keys(Keys.sph)
 
         # confirm upload layers
         confuplayer = pla.xpath_finduniq(

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -42,7 +42,7 @@ class ShapeTest(unittest.TestCase):
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",
              100, 1)
-        chooselayer.upload.send_keys(sph)
+        chooselayer.send_keys(os.path.join(os.getcwd(), sph))
 
         # confirm upload layers
         confuplayer = pla.xpath_finduniq(

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -33,6 +33,8 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
+        import pdb ; pdb.set_trace()
+
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",
              100, 1)

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -8,15 +8,6 @@ from selenium.webdriver.common.keys import Keys
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):
-        # sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
-        #                                            'openquakeplatform',
-        #                                            'test',
-        #                                            'shapefile',
-        #                                            'exampleshape.zip')
-
-        sph = "~/oq-platform2/openquakeplatform/test/shapefile/exampleshape.zip"
-
-        print sph
 
         pla.get('')
 
@@ -37,6 +28,11 @@ class ShapeTest(unittest.TestCase):
         pla.wait_new_page(uploadlayer, '/layers/upload', timeout=10)
 
         # choose shape file
+        sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
+                                                    'openquakeplatform',
+                                                    'test',
+                                                    'shapefile',
+                                                    'exampleshape.zip')
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",
              100, 1)

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -8,11 +8,12 @@ from selenium.webdriver.common.keys import Keys
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):
-        # sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
-        #                                            'openquakeplatform',
-        #                                            'test/shapefile',
-        #                                            'exampleshape.zip')
-        sph = "~/oq-platform2/openquakeplatform/test/shapefile/exampleshape.zip"
+        sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
+                                                    'openquakeplatform',
+                                                    'test',
+                                                    'shapefile',
+                                                    'exampleshape.zip')
+        import pdb ; pdb.set_trace()
 
         pla.get('')
 

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -13,6 +13,8 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
+        print sph
+
         pla.get('')
 
         # layers in homepage

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -2,7 +2,6 @@
 import os
 import unittest
 from openquakeplatform.test import pla
-from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
@@ -35,8 +34,6 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
-
-        browser = webdriver.Firefox()
 
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -35,7 +35,6 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
-        # import pdb ; pdb.set_trace()
 
         browser = webdriver.Firefox()
 

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -2,6 +2,7 @@
 import os
 import unittest
 from openquakeplatform.test import pla
+from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
@@ -33,7 +34,7 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
-        import pdb ; pdb.set_trace()
+        # import pdb ; pdb.set_trace()
 
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -41,7 +41,7 @@ class ShapeTest(unittest.TestCase):
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",
              100, 1)
-        chooselayer.send_keys(Keys.sph)
+        chooselayer.send_keys(sph)
 
         # confirm upload layers
         confuplayer = pla.xpath_finduniq(

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -34,7 +34,7 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
-        # import pdb ; pdb.set_trace()
+        import pdb ; pdb.set_trace()
 
         chooselayer = pla.xpath_finduniq(
              "//input[@type='file'and @id='file-input']",

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -8,11 +8,14 @@ from selenium.webdriver.common.keys import Keys
 class ShapeTest(unittest.TestCase):
 
     def upload_shape_test(self):
-        sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
-                                                    'openquakeplatform',
-                                                    'test',
-                                                    'shapefile',
-                                                    'exampleshape.zip')
+        # sph = os.path.join(os.path.expanduser("~"), 'oq-platform2',
+        #                                            'openquakeplatform',
+        #                                            'test',
+        #                                            'shapefile',
+        #                                            'exampleshape.zip')
+
+        sph = "~/oq-platform2/openquakeplatform/test/shapefile/exampleshape.zip"
+
         print sph
 
         pla.get('')

--- a/openquakeplatform/test/shape_test.py
+++ b/openquakeplatform/test/shape_test.py
@@ -13,8 +13,6 @@ class ShapeTest(unittest.TestCase):
                                                     'test',
                                                     'shapefile',
                                                     'exampleshape.zip')
-        import pdb ; pdb.set_trace()
-
         pla.get('')
 
         # layers in homepage

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -46,7 +46,7 @@ exec_test () {
     # cd $GIT_REPO
     export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
 
-    #sleep 50000
+    sleep 50000
 
     export DISPLAY=:1
     python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test/shape_test.py # || true

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -161,7 +161,7 @@ paver sync
 paver start -b 0.0.0.0:8000
 
 
-sleep 50000
+# sleep 50000
 
 cd ~/ 
 if [ "$NO_EXEC_TEST" != "notest" ] ; then

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -31,8 +31,8 @@ geonode_setup_env()
 exec_test () {   
     #install selenium,pip,geckodriver,clone oq-moon and execute tests with nose
     sudo apt-get -y install python-pip wget
-    sudo pip install --upgrade pip
-    sudo pip install nose
+    pip install --upgrade pip
+    pip install nose
     wget "http://ftp.openquake.org/common/selenium-deps"
     GEM_FIREFOX_VERSION="$(dpkg-query --show -f '${Version}' firefox)"
     . selenium-deps

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -46,6 +46,8 @@ exec_test () {
     # cd $GIT_REPO
     export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
 
+    sleep 50000
+
     export DISPLAY=:1
     python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test # || true
     # sleep 40000 || true

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -44,7 +44,7 @@ exec_test () {
     cp $GIT_REPO/openquakeplatform/test/config/moon_config.py.tmpl $GIT_REPO/openquakeplatform/test/config/moon_config.py
     
     # cd $GIT_REPO
-    export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
+    export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt:$HOME/openquakeplatform/test
 
     #sleep 50000
 

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -46,7 +46,7 @@ exec_test () {
     # cd $GIT_REPO
     export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
 
-    sleep 50000
+    #sleep 50000
 
     export DISPLAY=:1
     python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test/shape_test.py # || true

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -113,6 +113,7 @@ sudo service postgresql restart
 
 #install numpy
 pip install numpy
+pip install shapely
 
 
 ## Clone GeoNode
@@ -130,7 +131,7 @@ pip install -e .
 # pip install pygdal==1.11.3.3
 
 # Install the system python-gdal
-sudo apt-get install -y python-gdal python-shapely
+sudo apt-get install -y python-gdal
 
 cd ~
 # Create a symbolic link in your virtualenv

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -29,13 +29,17 @@ geonode_setup_env()
 
 #function complete procedure for tests
 exec_test () {   
-    #install selenium,pip,geckodriver,clone oq-moon and execute tests with nose 
+    #install selenium,pip,geckodriver,clone oq-moon and execute tests with nose
     sudo apt-get -y install python-pip wget
-    pip install --upgrade pip
-    pip install nose
-    pip install -U selenium==3.4.1
-    wget http://ftp.openquake.org/mirror/mozilla/geckodriver-v0.16.1-linux64.tar.gz ; tar zxvf geckodriver-v0.16.1-linux64.tar.gz ; sudo cp geckodriver /usr/local/bin
-
+    sudo pip install --upgrade pip
+    sudo pip install nose
+    wget "http://ftp.openquake.org/common/selenium-deps"
+    GEM_FIREFOX_VERSION="$(dpkg-query --show -f '${Version}' firefox)"
+    . selenium-deps
+    wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    sudo cp geckodriver /usr/local/bin
+    sudo pip install -U selenium==${GEM_SELENIUM_VERSION}
     git clone -b "$GIT_BRANCH" "$GEM_GIT_REPO/oq-moon.git" || git clone -b oq-platform2 "$GEM_GIT_REPO/oq-moon.git" || git clone "$GEM_GIT_REPO/oq-moon.git"
     cp $GIT_REPO/openquakeplatform/test/config/moon_config.py.tmpl $GIT_REPO/openquakeplatform/test/config/moon_config.py
     

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -160,6 +160,9 @@ cd ~/geonode
 paver sync
 paver start -b 0.0.0.0:8000
 
+
+sleep 50000
+
 cd ~/ 
 if [ "$NO_EXEC_TEST" != "notest" ] ; then
     exec_test

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -44,7 +44,7 @@ exec_test () {
     cp $GIT_REPO/openquakeplatform/test/config/moon_config.py.tmpl $GIT_REPO/openquakeplatform/test/config/moon_config.py
     
     # cd $GIT_REPO
-    export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt:$HOME/openquakeplatform/test
+    export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
 
     #sleep 50000
 
@@ -166,7 +166,7 @@ paver start -b 0.0.0.0:8000
 
 # sleep 50000
 
-# cd ~/ 
+cd ~/ 
 if [ "$NO_EXEC_TEST" != "notest" ] ; then
     exec_test
 fi

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -166,7 +166,7 @@ paver start -b 0.0.0.0:8000
 
 # sleep 50000
 
-cd ~/ 
+# cd ~/ 
 if [ "$NO_EXEC_TEST" != "notest" ] ; then
     exec_test
 fi

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -112,7 +112,7 @@ sudo sed -i '1 s@^@local  all             all             md5\n@g' /etc/postgres
 sudo service postgresql restart
 
 #install numpy
-pip install numpy shapely
+pip install numpy
 
 
 ## Clone GeoNode
@@ -130,7 +130,7 @@ pip install -e .
 # pip install pygdal==1.11.3.3
 
 # Install the system python-gdal
-sudo apt-get install -y python-gdal
+sudo apt-get install -y python-gdal python-shapely
 
 cd ~
 # Create a symbolic link in your virtualenv

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -113,7 +113,7 @@ sudo service postgresql restart
 
 #install numpy
 pip install numpy
-pip install shapely
+pip install shapely==1.5.13
 
 
 ## Clone GeoNode

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -38,8 +38,8 @@ exec_test () {
     . selenium-deps
     wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
-    sudo cp geckodriver /usr/local/bin
-    sudo pip install -U selenium==${GEM_SELENIUM_VERSION}
+    cp geckodriver /usr/local/bin
+    pip install -U selenium==${GEM_SELENIUM_VERSION}
     git clone -b "$GIT_BRANCH" "$GEM_GIT_REPO/oq-moon.git" || git clone -b oq-platform2 "$GEM_GIT_REPO/oq-moon.git" || git clone "$GEM_GIT_REPO/oq-moon.git"
     cp $GIT_REPO/openquakeplatform/test/config/moon_config.py.tmpl $GIT_REPO/openquakeplatform/test/config/moon_config.py
     

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -49,7 +49,7 @@ exec_test () {
     #sleep 50000
 
     export DISPLAY=:1
-    python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test/shape_test.py # || true
+    python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test # || true
     # sleep 40000 || true
 }
 

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -46,10 +46,10 @@ exec_test () {
     # cd $GIT_REPO
     export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
 
-    sleep 50000
+    #sleep 50000
 
     export DISPLAY=:1
-    python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test # || true
+    python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test/shape_test.py # || true
     # sleep 40000 || true
 }
 

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -46,8 +46,6 @@ exec_test () {
     # cd $GIT_REPO
     export PYTHONPATH=$HOME/oq-moon:$HOME/$GIT_REPO:$HOME/$GIT_REPO/openquakeplatform/test/config:$HOME/oq-platform-taxtweb:$HOME/oq-platform-ipt
 
-    #sleep 50000
-
     export DISPLAY=:1
     python -m openquake.moon.nose_runner --failurecatcher dev -s -v --with-xunit --xunit-file=xunit-platform-dev.xml $GIT_REPO/openquakeplatform/test # || true
     # sleep 40000 || true
@@ -163,8 +161,6 @@ cd ~/geonode
 paver sync
 paver start -b 0.0.0.0:8000
 
-
-# sleep 50000
 
 cd ~/ 
 if [ "$NO_EXEC_TEST" != "notest" ] ; then

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -38,7 +38,7 @@ exec_test () {
     . selenium-deps
     wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
-    cp geckodriver /usr/local/bin
+    sudo cp geckodriver /usr/local/bin
     pip install -U selenium==${GEM_SELENIUM_VERSION}
     git clone -b "$GIT_BRANCH" "$GEM_GIT_REPO/oq-moon.git" || git clone -b oq-platform2 "$GEM_GIT_REPO/oq-moon.git" || git clone "$GEM_GIT_REPO/oq-moon.git"
     cp $GIT_REPO/openquakeplatform/test/config/moon_config.py.tmpl $GIT_REPO/openquakeplatform/test/config/moon_config.py

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -161,7 +161,6 @@ cd ~/geonode
 paver sync
 paver start -b 0.0.0.0:8000
 
-
 cd ~/ 
 if [ "$NO_EXEC_TEST" != "notest" ] ; then
     exec_test

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -36,8 +36,9 @@ exec_test () {
     wget "http://ftp.openquake.org/common/selenium-deps"
     GEM_FIREFOX_VERSION="$(dpkg-query --show -f '${Version}' firefox)"
     . selenium-deps
-    wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
-    tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    # wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    # tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    wget http://ftp.openquake.org/mirror/mozilla/geckodriver-v0.16.1-linux64.tar.gz ; tar zxvf geckodriver-v0.16.1-linux64.tar.gz ; sudo cp geckodriver /usr/local/bin
     sudo cp geckodriver /usr/local/bin
     pip install -U selenium==${GEM_SELENIUM_VERSION}
     git clone -b "$GIT_BRANCH" "$GEM_GIT_REPO/oq-moon.git" || git clone -b oq-platform2 "$GEM_GIT_REPO/oq-moon.git" || git clone "$GEM_GIT_REPO/oq-moon.git"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -38,8 +38,6 @@ exec_test () {
     . selenium-deps
     wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
-    # wget http://ftp.openquake.org/mirror/mozilla/geckodriver-v0.16.1-linux64.tar.gz
-    # tar zxvf geckodriver-v0.16.1-linux64.tar.gz
     sudo cp geckodriver /usr/local/bin
     pip install -U selenium==${GEM_SELENIUM_VERSION}
     git clone -b "$GIT_BRANCH" "$GEM_GIT_REPO/oq-moon.git" || git clone -b oq-platform2 "$GEM_GIT_REPO/oq-moon.git" || git clone "$GEM_GIT_REPO/oq-moon.git"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -36,9 +36,10 @@ exec_test () {
     wget "http://ftp.openquake.org/common/selenium-deps"
     GEM_FIREFOX_VERSION="$(dpkg-query --show -f '${Version}' firefox)"
     . selenium-deps
-    # wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
-    # tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
-    wget http://ftp.openquake.org/mirror/mozilla/geckodriver-v0.16.1-linux64.tar.gz ; tar zxvf geckodriver-v0.16.1-linux64.tar.gz ; sudo cp geckodriver /usr/local/bin
+    wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
+    # wget http://ftp.openquake.org/mirror/mozilla/geckodriver-v0.16.1-linux64.tar.gz
+    # tar zxvf geckodriver-v0.16.1-linux64.tar.gz
     sudo cp geckodriver /usr/local/bin
     pip install -U selenium==${GEM_SELENIUM_VERSION}
     git clone -b "$GIT_BRANCH" "$GEM_GIT_REPO/oq-moon.git" || git clone -b oq-platform2 "$GEM_GIT_REPO/oq-moon.git" || git clone "$GEM_GIT_REPO/oq-moon.git"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -112,7 +112,7 @@ sudo sed -i '1 s@^@local  all             all             md5\n@g' /etc/postgres
 sudo service postgresql restart
 
 #install numpy
-pip install numpy
+pip install numpy shapely
 
 
 ## Clone GeoNode


### PR DESCRIPTION
Added changes for firefox 55, Selenium 3.5.0 and geckodriver 0.18
Tests on continous integration are green here: https://ci.openquake.org/job/zdevel_oq-platform2/122/