### PR TITLE
Test to visualize list maps and create new map without login

### DIFF
--- a/openquakeplatform/test/maps_test.py
+++ b/openquakeplatform/test/maps_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import unittest
+from openquake.moon import platform_get
+
+TIMEOUT = 100
+
+
+class MapsTest(unittest.TestCase):
+
+    def map_no_login_test(self):
+
+        pla = platform_get()
+
+        # New window with platform without login
+        plb = pla.platform_create(user=None, passwd=None)
+        plb.init(landing='/', autologin=False)
+
+        # To visualize maps list
+        list_maps = plb.xpath_finduniq(
+            "//a[@href='/maps/' and @class='oq-button-home-btn btn']", TIMEOUT)
+        list_maps.click()
+
+        # Create new map
+        create_new_map = plb.xpath_finduniq(
+            "//a[@href='/maps/new' and"
+            " @class='btn btn-primary pull-right']", TIMEOUT)
+        create_new_map.click()
+
+        # Check page new map
+        plb.wait_new_page(create_new_map, '/maps/new', timeout=10)
+
+        # Check warning must login
+        plb.xpath_finduniq(
+            "//div[@class='map_warning']", TIMEOUT)
+
+        pla.platform_destroy(plb)

--- a/openquakeplatform/test/maps_test.py
+++ b/openquakeplatform/test/maps_test.py
@@ -7,7 +7,7 @@ TIMEOUT = 100
 
 class MapsTest(unittest.TestCase):
 
-    def map_no_login_test(self):
+    def new_map_page_no_login_test(self):
 
         pla = platform_get()
 


### PR DESCRIPTION
Added test to visualize list maps and create new map without login
The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform2/366/
Fixes #32