### PR TITLE
Engine's version from 2.8 to 3.0

### DIFF
--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -155,7 +155,7 @@ fi
 ## install engine
 sudo apt-get install -y software-properties-common
 # sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master
-sudo add-apt-repository -y ppa:openquake/release-3.0
+sudo add-apt-repository -y ppa:openquake/release-3.1
 sudo apt-get update
 sudo apt-get install -y --force-yes python-oq-engine
 

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -155,7 +155,7 @@ fi
 ## install engine
 sudo apt-get install -y software-properties-common
 # sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master
-sudo add-apt-repository -y ppa:openquake/release-3.1
+sudo add-apt-repository -y ppa:openquake/release-3.0
 sudo apt-get update
 sudo apt-get install -y --force-yes python-oq-engine
 

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -155,7 +155,7 @@ fi
 ## install engine
 sudo apt-get install -y software-properties-common
 # sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master
-sudo add-apt-repository -y ppa:openquake/release-2.8
+sudo add-apt-repository -y ppa:openquake/release-3.0
 sudo apt-get update
 sudo apt-get install -y --force-yes python-oq-engine
 


### PR DESCRIPTION
Engine's version from 2.8 to 3.0
Changed Engine's version when it install from packages during  platform's installation.
The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform2/488/