### PR TITLE
 Truncated metadata

### DIFF
--- a/openquakeplatform/templates/base/_resourcebase_info_panel.html
+++ b/openquakeplatform/templates/base/_resourcebase_info_panel.html
@@ -129,7 +129,7 @@
 
     {% if resource.purpose %}
     <dt>{% trans "Purpose" %}</dt>
-    <dd>{{ resource.purpose|escape|urlize|linebreaks|safe|truncatechars:160 }}</dd>
+    <dd>{{ resource.purpose|escape|urlize|linebreaks|safe }}</dd>
     {% endif %}
 
     {% if resource.language %}
@@ -149,7 +149,7 @@
 
     {% if resource.supplemental_information and resource.category|stringformat:"s" != 'SVIR' %}
     <dt>{% trans "Supplemental Information" %}</dt>
-    <dd>{{ resource.supplemental_information|truncatechars:160|escape|urlize|linebreaks|safe }}</dd>
+    <dd>{{ resource.supplemental_information|escape|urlize|linebreaks|safe }}</dd>
     {% endif %}
 
     {% if resource.spatial_representation_type %}

--- a/openquakeplatform/templates/metadata_detail.html
+++ b/openquakeplatform/templates/metadata_detail.html
@@ -219,7 +219,7 @@
 
         {% if resource.purpose %}
         <dt>{% trans "Purpose" %}</dt>
-        <dd>{{ resource.purpose|escape|urlize|linebreaks|safe|truncatechars:160 }}</dd>
+        <dd>{{ resource.purpose|escape|urlize|linebreaks|safe }}</dd>
         {% endif %}
 
         {% if resource.language %}
@@ -239,7 +239,7 @@
 
         {% if resource.supplemental_information and resource.category|stringformat:"s" != 'SVIR' %}
         <dt>{% trans "Supplemental Information" %}</dt>
-        <dd>{{ resource.supplemental_information|truncatechars:160|escape|urlize|linebreaks|safe }}</dd>
+        <dd>{{ resource.supplemental_information|escape|urlize|linebreaks|safe }}</dd>
         {% endif %}
 
         {% if resource.spatial_representation_type %}


### PR DESCRIPTION
Fixed problem with truncation Supplemental information and Purpose inside the:

- Info tab panel for layers, maps and documents
- Metadata detail's page

The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform2/880/

See also:

- https://platform-staging.openquake.org/maps/80
- https://platform-staging.openquake.org/maps/80/metadata_detail

Close #86 