### PR TITLE
Extended check migrations

### DIFF
--- a/openquakeplatform/migrations_test.py
+++ b/openquakeplatform/migrations_test.py
@@ -39,7 +39,28 @@ class VulnMigrationTest(MigrationTest):
         be_gen.save()
         return be_gen
 
-    def test_migration_model_none(self):
+    def after_migr(self, func_name):
+
+        # after migrations
+        GeneralInformation_af = self.get_model_after('GeneralInformation')
+        VulnerabilityFunc_af = self.get_model_after('VulnerabilityFunc')
+
+        af_gen = GeneralInformation_af.objects.get(name=func_name)
+
+        af_vul_f = VulnerabilityFunc_af.objects.get(resp_var="5")
+
+        af_dtldiscr = (af_gen.damage_to_loss_func.func_distr_dtl_discr)
+        af_vuln_discr = af_vul_f.func_distr_vuln_discr
+
+        # check func_distr_shape, var_val_coeff, resp_var_val_coeff
+        self.assertEqual(af_dtldiscr.func_distr_shape, FDS.LOGNORMAL)
+        self.assertEqual(af_dtldiscr.var_val_coeff, '0;0;0;0;0')
+        self.assertEqual(af_vuln_discr.resp_var_val_coeff, '0;0;0;0;0')
+
+
+class VulnMigrationNoneTest(VulnMigrationTest):
+
+    def test_migration_model(self):
 
         owner = create_user()
 
@@ -91,7 +112,10 @@ class VulnMigrationTest(MigrationTest):
         # tests after migrations
         self.after_migr(be_gen.name)
 
-    def test_migration_model_empty(self):
+
+class VulnMigrationEmptyTest(VulnMigrationTest):
+
+    def test_migration_model(self):
 
         owner = create_user()
         be_gen = self.gen_information(owner, 'Empty')
@@ -141,20 +165,3 @@ class VulnMigrationTest(MigrationTest):
 
         # tests after migrations
         self.after_migr(be_gen.name)
-
-    def after_migr(self, func_name):
-        # after migrations
-        GeneralInformation_af = self.get_model_after('GeneralInformation')
-        VulnerabilityFunc_af = self.get_model_after('VulnerabilityFunc')
-
-        af_gen = GeneralInformation_af.objects.get(name=func_name)
-
-        af_vul_f = VulnerabilityFunc_af.objects.get(resp_var="5")
-
-        af_dtldiscr = (af_gen.damage_to_loss_func.func_distr_dtl_discr)
-        af_vuln_discr = af_vul_f.func_distr_vuln_discr
-
-        # check func_distr_shape, var_val_coeff, resp_var_val_coeff
-        self.assertEqual(af_dtldiscr.func_distr_shape, FDS.LOGNORMAL)
-        self.assertEqual(af_dtldiscr.var_val_coeff, '0;0;0;0;0')
-        self.assertEqual(af_vuln_discr.resp_var_val_coeff, '0;0;0;0;0')

--- a/openquakeplatform/migrations_test.py
+++ b/openquakeplatform/migrations_test.py
@@ -70,7 +70,7 @@ class VulnMigrationTest(MigrationTest):
             owner_id=owner.pk,
             vulnerability_func=be_vulnfunc,
             resp_var_mean_val="0.1;0.2;0.4;0.9;1",
-            resp_var_val_coeff=None,
+            resp_var_val_coeff="",
             data_pts_num="3"
             )
         be_distr_vuln_discr.save()

--- a/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
+++ b/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
@@ -19,8 +19,8 @@ def forwards_func(apps, schema_editor):
     for func in funcs:
         to_save = False
 
-        if func.var_mean_val is not None:
-            if func.var_val_coeff is None:
+        if func.var_mean_val is not None or func.var_mean_val == "":
+            if func.var_val_coeff is None or func.var_val_coeff == "":
                 func.var_val_coeff = ";".join(
                     "0" * len(func.var_mean_val.split(';')))
                 to_save = True
@@ -39,8 +39,9 @@ def forwards_func(apps, schema_editor):
     for func in funcs:
         to_save = False
 
-        if func.resp_var_mean_val is not None:
-            if func.resp_var_val_coeff is None:
+        if func.resp_var_mean_val is not None or func.resp_var_mean_val == "":
+            if (func.resp_var_val_coeff is None
+               or func.resp_var_val_coeff == ""):
                 func.resp_var_val_coeff = ";".join(
                     "0" * len(func.resp_var_mean_val.split(';')))
                 to_save = True

--- a/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
+++ b/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
@@ -19,7 +19,7 @@ def forwards_func(apps, schema_editor):
     for func in funcs:
         to_save = False
 
-        if func.var_mean_val is not None or func.var_mean_val == "":
+        if func.var_mean_val is not None and func.var_mean_val != "":
             if func.var_val_coeff is None or func.var_val_coeff == "":
                 func.var_val_coeff = ";".join(
                     "0" * len(func.var_mean_val.split(';')))
@@ -39,7 +39,7 @@ def forwards_func(apps, schema_editor):
     for func in funcs:
         to_save = False
 
-        if func.resp_var_mean_val is not None or func.resp_var_mean_val == "":
+        if func.resp_var_mean_val is not None and func.resp_var_mean_val != "":
             if (func.resp_var_val_coeff is None
                or func.resp_var_val_coeff == ""):
                 func.resp_var_val_coeff = ";".join(

--- a/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
+++ b/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
@@ -27,6 +27,8 @@ def forwards_func(apps, schema_editor):
 
             if to_save:
                 func.save()
+        else:
+            raise ValueError('"var_mean_val" is none')
 
     # FIX resp_var_val_coeff for each type of curve
     cls = FuncDistrVulnDiscr
@@ -45,6 +47,8 @@ def forwards_func(apps, schema_editor):
 
             if to_save:
                 func.save()
+        else:
+            raise ValueError('"resp_var_mean_val" is none')
 
 
 def backwards_func(apps, schema_editor):

--- a/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
+++ b/openquakeplatform/vulnerability/migrations/0004_func_dist_vuln_dtl_ctx.py
@@ -28,7 +28,7 @@ def forwards_func(apps, schema_editor):
             if to_save:
                 func.save()
         else:
-            raise ValueError('"var_mean_val" is none')
+            raise ValueError('"var_mean_val" is None')
 
     # FIX resp_var_val_coeff for each type of curve
     cls = FuncDistrVulnDiscr
@@ -48,7 +48,7 @@ def forwards_func(apps, schema_editor):
             if to_save:
                 func.save()
         else:
-            raise ValueError('"resp_var_mean_val" is none')
+            raise ValueError('"resp_var_mean_val" is None')
 
 
 def backwards_func(apps, schema_editor):


### PR DESCRIPTION
Added or empty for checking "var_val_coeff" and "resp_var_val_coeff" inside the 0004 migration of vulnerability.
Changed the test migration.

The tests are running here: https://ci.openquake.org/job/zdevel_oq-platform2/1051/