### PR TITLE
Setuptools for python 2.7

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -46,6 +46,8 @@ sudo mkdir -p /var/lib/geonode/env
 sudo virtualenv /var/lib/geonode/env
 source /var/lib/geonode/env/bin/activate
 
+sudo /var/lib/geonode/env/bin/python -m pip install "setuptools==44.0.0"
+
 sudo /var/lib/geonode/env/bin/python -m pip install "numpy>=1.16,<1.17"
 
 sudo /var/lib/geonode/env/bin/python -m pip install "django<2"

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -46,6 +46,7 @@ sudo mkdir -p /var/lib/geonode/env
 sudo virtualenv /var/lib/geonode/env
 source /var/lib/geonode/env/bin/activate
 
+#install setuptools specitic version for python 2.7
 sudo /var/lib/geonode/env/bin/python -m pip install "setuptools==44.0.0"
 
 sudo /var/lib/geonode/env/bin/python -m pip install "numpy>=1.16,<1.17"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -230,6 +230,9 @@ fi
 #restart postgres
 sudo service postgresql restart
 
+#install setuptools specitic version for python 2.7
+pip install "setuptools==44.0.0"
+
 #install numpy
 pip install "numpy>=1.16,<1.17"
 


### PR DESCRIPTION
Added specific version of setuptools for python 2.7, dev and prod installation.

The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform2/1108/