### PR TITLE
Jdk correct version installation

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -43,7 +43,7 @@ sudo apt install -y python-dev libpq-dev libgdal-dev
 function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/
-   mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
+   sudo mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
    wget http://ftp.openquake.org/oq-platform2/8u242.tgz
    tar zxvf 8u242.tgz
    update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -40,7 +40,7 @@ sudo apt install -y python-dev libpq-dev libgdal-dev
 
 # install last version of jdk 1-8-0_265 and downgrade to 1.8.0.242 used from Geoserver
 
-function install jdk() {
+function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/
    mv java-8-openjdk-amd64 java-8-openjdk-amd64.last

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -44,9 +44,9 @@ function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/
    sudo mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
-   wget http://ftp.openquake.org/oq-platform2/8u242.tgz
-   tar zxvf 8u242.tgz
-   update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1
+   sudo wget http://ftp.openquake.org/oq-platform2/8u242.tgz
+   sudo tar zxvf 8u242.tgz
+   sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1
 }
 
 install_jdk

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -36,7 +36,20 @@ sudo service apache2 restart || true
 sudo apt-get update
 sudo apt install -y git python-virtualenv wget
 
-sudo apt install -y python-dev libpq-dev libgdal-dev openjdk-8-jdk-headless
+sudo apt install -y python-dev libpq-dev libgdal-dev
+
+# install last version of jdk 1-8-0_265 and downgrade to 1.8.0.242 used from Geoserver
+
+function install jdk() {
+   sudo apt install -y openjdk-8-jdk-headless
+   cd /usr/lib/jvm/
+   mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
+   wget http://ftp.openquake.org/oq-platform2/8u242.tgz
+   tar zxvf 8u242.tgz
+   update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1
+}
+
+install_jdk
 
 sudo apt-get install -y postgresql-9.5-postgis-2.2 postgresql-9.5-postgis-scripts curl xmlstarlet supervisor
 sudo apt install -y apache2 tomcat7

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -52,7 +52,10 @@ function install_jdk() {
 install_jdk
 
 sudo apt-get install -y postgresql-9.5-postgis-2.2 postgresql-9.5-postgis-scripts curl xmlstarlet supervisor
-sudo apt install -y apache2 tomcat7
+sudo apt install -y apache2
+
+# Install Tomcat and Tomcat manager (hostname:8080/manager on the web)
+sudo apt install -y tomcat7 tomcat7-admin
 
 # Create and source virtual env
 sudo mkdir -p /var/lib/geonode/env

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -39,7 +39,6 @@ sudo apt install -y git python-virtualenv wget
 sudo apt install -y python-dev libpq-dev libgdal-dev
 
 # install last version of jdk 1-8-0_265 and downgrade to 1.8.0.242 used from Geoserver
-
 function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -138,9 +138,9 @@ function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/
    sudo mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
-   wget http://ftp.openquake.org/oq-platform2/8u242.tgz
-   tar zxvf 8u242.tgz
-   update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1
+   sudo wget http://ftp.openquake.org/oq-platform2/8u242.tgz
+   sudo tar zxvf 8u242.tgz
+   sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1
 }
 
 install_jdk

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -134,7 +134,7 @@ sudo apt update
 sudo apt install -y git python-dev python-virtualenv libpq-dev libgdal-dev zip unzip
 
 # install last version of jdk 1-8-0_265 and downgrade to 1.8.0.242 used from Geoserver
-function install jdk() {
+function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/
    mv java-8-openjdk-amd64 java-8-openjdk-amd64.last

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -137,7 +137,7 @@ sudo apt install -y git python-dev python-virtualenv libpq-dev libgdal-dev zip u
 function install_jdk() {
    sudo apt install -y openjdk-8-jdk-headless
    cd /usr/lib/jvm/
-   mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
+   sudo mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
    wget http://ftp.openquake.org/oq-platform2/8u242.tgz
    tar zxvf 8u242.tgz
    update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -131,7 +131,19 @@ fi
 
 
 sudo apt update
-sudo apt install -y git python-dev python-virtualenv libpq-dev libgdal-dev openjdk-8-jdk-headless zip unzip
+sudo apt install -y git python-dev python-virtualenv libpq-dev libgdal-dev zip unzip
+
+# install last version of jdk 1-8-0_265 and downgrade to 1.8.0.242 used from Geoserver
+function install jdk() {
+   sudo apt install -y openjdk-8-jdk-headless
+   cd /usr/lib/jvm/
+   mv java-8-openjdk-amd64 java-8-openjdk-amd64.last
+   wget http://ftp.openquake.org/oq-platform2/8u242.tgz
+   tar zxvf 8u242.tgz
+   update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 1
+}
+
+install_jdk
 
 # Used a local clone (see verifier.sh)
 # git clone -b "$GIT_BRANCH" https://github.com/gem/oq-platform2.git


### PR DESCRIPTION
Added the function where doing downgrade from jdk 1.0.8_265 to 1.0.8_24 used by Geoserver 2.0.9 Snaphot oauth2. in development and production installations.

Added install of Tomcat7 web manager in production installation.


The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform2/1146/