### PR TITLE
Fix Global Risk Viewer test

### DIFF
--- a/openquakeplatform/test/grv_test.py
+++ b/openquakeplatform/test/grv_test.py
@@ -31,6 +31,8 @@ class GrvTest(unittest.TestCase):
         category_tabs = pla.xpath_finduniq(
             "//div[@id='categoryTabs']", TIMEOUT)
 
+        pla.scroll_into_view(category_tabs)
+
         # test fails if the svg is not found
         economy_tabs = pla.xpath_finduniq(
             "//div[@id='economy']"

--- a/openquakeplatform/test/grv_test.py
+++ b/openquakeplatform/test/grv_test.py
@@ -26,8 +26,6 @@ class GrvTest(unittest.TestCase):
         action_chart.move_to_element_with_offset(
             content_map, 550, 50).click().perform()
 
-        # import time
-        # time.sleep(50000)
         category_tabs = pla.xpath_finduniq(
             "//div[@id='categoryTabs']", TIMEOUT)
 
@@ -43,6 +41,3 @@ class GrvTest(unittest.TestCase):
             el=category_tabs)
 
         pla.scroll_into_view(economy_tabs)
-
-        # import time
-        # time.sleep(5000000)


### PR DESCRIPTION
Added into scroll function inside the Global Risk Viewer test before click to economy tab.
Clean commented code not used more.

The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform2/1159/